### PR TITLE
Modify: remove emit countdown in select-success

### DIFF
--- a/src/socket.js
+++ b/src/socket.js
@@ -153,7 +153,6 @@ function createWsServer(httpServer) {
       socket.point = point;
 
       selectTimer = clearInterval(selectTimer);
-      wsServer.to(roomName).emit(COUNTDOWN, 0);
       wsServer.to(roomName).emit(SELECT_SUCCESS, point, socket.id);
     });
 


### PR DESCRIPTION
소켓 이벤트 "select-success"에서 countdown을 0으로 보내는 것을 삭제하였습니다.
(대신 클라이언트 쪽에서 "select-success"이벤트를 받으면 선택시간을 0으로 변경하도록 하였습니다.)